### PR TITLE
Walk/pretty print comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Walk comments in `walkGherkinDocument`
+- Pretty print comments in `pretty`
 
 ## [8.0.2] - 2022-11-21
 ### Added

--- a/javascript/src/pretty.ts
+++ b/javascript/src/pretty.ts
@@ -9,6 +9,9 @@ export default function pretty(
 ): string {
   let scenarioLevel = 1
   return walkGherkinDocument<string>(gherkinDocument, '', {
+    comment(comment, content) {
+      return content.concat(comment.text).concat('\n')
+    },
     feature(feature, content) {
       return content
         .concat(prettyLanguageHeader(feature.language))

--- a/javascript/test/prettyTest.ts
+++ b/javascript/test/prettyTest.ts
@@ -149,18 +149,28 @@ Feature: hello
     })
   })
 
-  xit('renders comments', () => {
+  it('renders comments', () => {
     checkGherkinToAstToGherkin(`# one
+# two
 Feature: hello
+  # three
+  # four
 
   Scenario: one
-    # two
+    # five
+    # six
     Given a doc string:
       """
       a
       \\"\\"\\"
       b
       """
+`)
+  })
+
+  it('renders just comments', () => {
+    checkGherkinToAstToGherkin(`# one
+# two
 `)
   })
 


### PR DESCRIPTION
**NB:** This is a port of [cucumber/common#1738](https://github.com/cucumber/common/pull/1738) authored by @aslakhellesoy. I've patched the changes over from the monorepo to encourage conversation, but I am not the author nor am I intimately familiar with the problem.

## Summary
* Walk comments in `walkGherkinDocument`
* Pretty print comments in `pretty`

## Details
Keep a stack of comments and pop/walk comments until the current AST node.

## How Has This Been Tested?
I've just added a couple of unit tests - we need more thorough tests for this:

* [ ]  Add comments everywhere in `walkGherkinDocumentTest`
* [ ]  Add more edge case tests for `pretty`

## Screenshots (if appropriate):
## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue).
* [ ]  New feature (non-breaking change which adds functionality).
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
* [ ]  The change has been ported to Java.
* [ ]  The change has been ported to Ruby.
* [x]  The change has been ported to JavaScript.
* [ ]  The change has been ported to Go.
* [ ]  The change has been ported to .NET.
* [ ]  I've added tests for my code.
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [ ]  I have updated the CHANGELOG accordingly.

