### PR TITLE
Fix rule filtering in the document walker

### DIFF
--- a/javascript/src/GherkinDocumentWalker.ts
+++ b/javascript/src/GherkinDocumentWalker.ts
@@ -201,8 +201,8 @@ export default class GherkinDocumentWalker {
 
     this.handlers.handleRule(rule)
 
-    const backgroundKept = children.find((child) => child !== null && child.background !== null)
-    const scenariosKept = children.filter((child) => child !== null && child.scenario !== null)
+    const backgroundKept = children.find((child) => child !== null && child.background)
+    const scenariosKept = children.filter((child) => child !== null && child.scenario)
 
     if (this.filters.acceptRule(rule) || backgroundKept) {
       return this.copyRule(rule, rule.children)

--- a/javascript/test/GherkinDocumentWalkerTest.ts
+++ b/javascript/test/GherkinDocumentWalkerTest.ts
@@ -155,8 +155,7 @@ Feature: hello
       assert.strictEqual(newSource, expectedNewSource)
     })
 
-    // TODO before merging https://github.com/cucumber/cucumber/pull/1419
-    xit('keeps a hit background', () => {
+    it('keeps a hit background', () => {
       const gherkinDocument = parse(`Feature: Solar System
 
   Background: Space
@@ -231,8 +230,7 @@ Feature: hello
       assert.strictEqual(newSource, expectedNewSource)
     })
 
-    // TODO before merging https://github.com/cucumber/cucumber/pull/1419
-    xit('keeps scenario in rule', () => {
+    it('keeps scenario in rule', () => {
       const gherkinDocument = parse(`Feature: Solar System
 
   Rule: Galaxy


### PR DESCRIPTION
### 🤔 What's changed?

Rules are now filtered when their all their children (background and scenarios) are themselves filtered.

### ⚡️ What's your motivation? 

Fix for https://github.com/cucumber/react-components/issues/136

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I have no experience in TypeScript so I'm not sure about the fix. It seems that the bug was about a difference in handling of `undefined` vs `null`.
Please feel free to modify anything as required.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
