### PR TITLE
Prevent introduction of trailing whitespace after headings with JavaScript formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- [JavaScript] Prevent the introduction of trailing whitespace after headings ([#34](https://github.com/cucumber/gherkin-utils/issues/34))
+
 ## [8.0.5] - 2023-06-02
 ### Changed
 - Upgrade to `@cucumber/messages` `22.0.0`

--- a/javascript/src/pretty.ts
+++ b/javascript/src/pretty.ts
@@ -74,6 +74,14 @@ function prettyLanguageHeader(language: string | undefined): string {
   return language === 'en' ? '' : `# language: ${language}\n`
 }
 
+function semiColumnName(name: string | null): string {
+  if (name == null || name.length == 0) {
+      return ':';
+  } else {
+      return ': ' + name;
+  }
+}
+
 function prettyKeywordContainer(
   stepContainer:
     | messages.Feature
@@ -93,8 +101,7 @@ function prettyKeywordContainer(
     .concat(prettyTags(tags, syntax, level))
     .concat(keywordPrefix(level, syntax))
     .concat(stepContainer.keyword)
-    .concat(': ')
-    .concat(stepContainer.name)
+    .concat(semiColumnName(stepContainer.name))
     .concat('\n')
     .concat(description)
     .concat(description && stepCount > 0 ? '\n' : '')

--- a/javascript/test/prettyTest.ts
+++ b/javascript/test/prettyTest.ts
@@ -209,6 +209,19 @@ Feature: hello
 `)
   })
 
+  it('renders titles without trailing whitespace', () => {
+    checkGherkinToAstToGherkin(`Feature:
+
+  Rule:
+
+    Background:
+    Scenario Outlines:
+
+      Examples:
+`)
+  })
+
+
   const featureFiles = fg.sync(`${__dirname}/../../testdata/good/*.feature`)
   for (const featureFile of featureFiles) {
     const relativePath = path.relative(__dirname, featureFile)


### PR DESCRIPTION
### 🤔 What's changed?

With the gherkin-utils JavaScript formatter, headings will have a trailing space introduced after them. When they have a title, this is not an issue, as the space is suffixed by the title itself i.e. `<heading>: <title>`. However, in the absence of a title - such as the typical use case of not including a title for `Examples:`, the formatter introduces a trailing space at the end of the headings.

This change ensures the space is included only when there is a title.

### ⚡️ What's your motivation? 

Prevents the introduction of unexpected artifacts into gherkin tests that use the formatter - the trailing whitespace; and fixes #34.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

To confirm the null check is required.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.