### PR TITLE
Preserve trailing comments. Fixes #38.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Preserve trailing comments at end of file when prettying in JavaScript.
 
 ### Fixed
 - [JavaScript] Prevent the introduction of trailing whitespace after headings ([#34](https://github.com/cucumber/gherkin-utils/issues/34))

--- a/javascript/src/walkGherkinDocument.ts
+++ b/javascript/src/walkGherkinDocument.ts
@@ -41,6 +41,7 @@ export function walkGherkinDocument<Acc>(
       }
     }
   }
+  acc = walkComments(popRemainingContents(), acc);
   return acc
 
   function walkComments(comments: readonly messages.Comment[], acc: Acc): Acc {
@@ -113,6 +114,10 @@ export function walkGherkinDocument<Acc>(
       }
     }
     return commentsStack.splice(0, count)
+  }
+
+  function popRemainingContents(): readonly messages.Comment[] {
+    return commentsStack.splice(0, commentsStack.length)
   }
 }
 

--- a/javascript/test/prettyTest.ts
+++ b/javascript/test/prettyTest.ts
@@ -190,6 +190,24 @@ Feature: hello
 `)
   })
 
+  it('renders trailing comments', () => {
+    checkGherkinToAstToGherkin(`# one
+Feature: hello
+
+  Scenario: one
+    # one
+    Given a doc string:
+      """
+      a
+      \\"\\"\\"
+      b
+      """
+      # two
+  # three
+# four
+`)
+  });
+
   it('renders descriptions when set', () => {
     checkGherkinToAstToGherkin(`Feature: hello
   So this is a feature


### PR DESCRIPTION
### 🤔 What's changed?

This fixes the bug described in #38.

### ⚡️ What's your motivation? 

Comments still aren't handled ideally; see #40 for some remaining issues. However, this bug is "destructive" i.e. the formatter can remove Gherkin statements that have been temporarily commented out.

It's better to fix the destructive bug quickly than to strive for perfection. We can discuss future refinements on #40.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
