### PR TITLE
Table formatting for full width characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [JavaScript] Prevent the introduction of trailing whitespace after headings ([#34](https://github.com/cucumber/gherkin-utils/issues/34))
 - [JavaScript] Fix GherkinDocumentWalker filtering of `Rules` (cucumber/react-components#136)
 - [JavaScript] Fix test execution in Windows - Closes (cucumber/gherkin-utils#2)
-- [JavaScript] Table formatting for full width characters ([#53](https://github.com/cucumber/gherkin-utils/pull/53))
+- Table formatting for full width characters ([#53](https://github.com/cucumber/gherkin-utils/pull/53))
 
 ## [8.0.5] - 2023-06-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [JavaScript] Prevent the introduction of trailing whitespace after headings ([#34](https://github.com/cucumber/gherkin-utils/issues/34))
 - [JavaScript] Fix GherkinDocumentWalker filtering of `Rules` (cucumber/react-components#136)
 - [JavaScript] Fix test execution in Windows - Closes (cucumber/gherkin-utils#2)
+- [JavaScript] Table formatting for full width characters ([#53](https://github.com/cucumber/gherkin-utils/pull/53))
 
 ## [8.0.5] - 2023-06-02
 ### Changed

--- a/java/src/main/java/io/cucumber/gherkin/utils/pretty/PrettyHandlers.java
+++ b/java/src/main/java/io/cucumber/gherkin/utils/pretty/PrettyHandlers.java
@@ -137,11 +137,7 @@ class PrettyHandlers implements GherkinDocumentHandlers<Result> {
     }
 
     private String semiColumnAndName(String name) {
-    	if (name == null || name.isEmpty()) {
-    		return ":";
-    	}
-    	
-		return ": " + name;
+        return (name == null || name.isEmpty()) ? ":" : ": " + name;
 	}
 
     private Result appendScenario(
@@ -328,7 +324,7 @@ class PrettyHandlers implements GherkinDocumentHandlers<Result> {
         for (TableRow tableRow : tableRows) {
             for (int j = 0; j < tableRow.getCells().size(); ++j) {
                 TableCell tableCell = tableRow.getCells().get(j);
-                maxWidths[j] = Math.max(maxWidths[j], escapeCell(tableCell.getValue()).length());
+                maxWidths[j] = Math.max(maxWidths[j], getStringWidth(escapeCell(tableCell.getValue())));
             }
         }
 
@@ -388,7 +384,7 @@ class PrettyHandlers implements GherkinDocumentHandlers<Result> {
             }
             TableCell tableCell = row.getCells().get(j);
             String escapedCellValue = escapeCell(tableCell.getValue());
-            int spaceCount = maxWidths[j] - escapedCellValue.length();
+            int spaceCount = maxWidths[j] - getStringWidth(escapedCellValue);
             String spaces = repeatString(spaceCount, " ");
             //res.append(isNumeric(escapedCellValue) ? spaces + escapedCellValue : escapedCellValue + spaces);
             result.append(escapedCellValue + spaces);
@@ -418,6 +414,18 @@ class PrettyHandlers implements GherkinDocumentHandlers<Result> {
         }
     }
 
+    private static int getStringWidth(String s) {
+        int width = 0;
+        for (char character : s.toCharArray()) {
+            width += isCJKorFullWidth(character) ? 2 : 1;
+        }
+        return width;
+    }
+
+    private static boolean isCJKorFullWidth(char character) {
+        Pattern pattern = Pattern.compile("[\\u3000-\\u9fff\\uac00-\\ud7af\\uff01-\\uff60]");
+        return pattern.matcher(String.valueOf(character)).find();
+    }
 
     private String escapeCell(String s) {
         StringBuilder e = new StringBuilder();

--- a/java/src/test/java/io/cucumber/gherkin/utils/pretty/PrettyTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/utils/pretty/PrettyTest.java
@@ -240,6 +240,26 @@ public class PrettyTest {
     }
 
     @Test
+    public void cjkTables() {
+        GherkinDocument gherkinDocument = parse("Feature: hello\n" +
+                "\n" +
+                "  Scenario: one\n" +
+                "    Given a data table:\n" +
+                "      |路| numbers |\n" +
+                "      |路|       1 |\n" +
+                "      |路步|      10 |\n" +
+                "      |路步路|     100 |\n");
+        assertEquals("Feature: hello\n" +
+                "\n" +
+                "  Scenario: one\n" +
+                "    Given a data table:\n" +
+                "      | 路     | numbers |\n" +
+                "      | 路     | 1       |\n" +
+                "      | 路步   | 10      |\n" +
+                "      | 路步路 | 100     |\n", prettyPrint(gherkinDocument, Syntax.gherkin));
+    }
+
+    @Test
     public void docString() {
         GherkinDocument gherkinDocument = parse("Feature: hello\n" +
                 "\n" +

--- a/javascript/src/pretty.ts
+++ b/javascript/src/pretty.ts
@@ -211,15 +211,15 @@ function prettyTableRow(
 
 function getStringWidth(str: string): number {
   let width = 0
-  for (const char of str) {
-    width += isCJKorFullWidth(char) ? 2 : 1
+  for (const character of str) {
+    width += isCJKorFullWidth(character) ? 2 : 1
   }
   return width
 }
 
-function isCJKorFullWidth(char: string): boolean {
+function isCJKorFullWidth(character: string): boolean {
   const pattern = /[\u3000-\u9fff\uac00-\ud7af\uff01-\uff60]/
-  return pattern.test(char)
+  return pattern.test(character)
 }
 
 export function escapeCell(s: string) {

--- a/javascript/src/pretty.ts
+++ b/javascript/src/pretty.ts
@@ -75,11 +75,7 @@ function prettyLanguageHeader(language: string | undefined): string {
 }
 
 function semiColumnName(name: string | null): string {
-  if (name == null || name.length == 0) {
-      return ':';
-  } else {
-      return ': ' + name;
-  }
+  return name == null || name.length == 0 ? ':' : ': ' + name
 }
 
 function prettyKeywordContainer(
@@ -172,7 +168,7 @@ function prettyTableRows(
   const maxWidths: number[] = new Array(tableRows[0].cells.length).fill(0)
   tableRows.forEach((tableRow) => {
     tableRow.cells.forEach((tableCell, j) => {
-      maxWidths[j] = Math.max(maxWidths[j], escapeCell(tableCell.value).length)
+      maxWidths[j] = Math.max(maxWidths[j], getStringWidth(escapeCell(tableCell.value)))
     })
   })
 
@@ -206,11 +202,24 @@ function prettyTableRow(
   return `${spaces(actualLevel)}| ${row.cells
     .map((cell, j) => {
       const escapedCellValue = escapeCell(cell.value)
-      const spaceCount = maxWidths[j] - escapedCellValue.length
+      const spaceCount = maxWidths[j] - getStringWidth(escapedCellValue)
       const spaces = new Array(spaceCount + 1).join(' ')
       return isNumeric(escapedCellValue) ? spaces + escapedCellValue : escapedCellValue + spaces
     })
     .join(' | ')} |\n`
+}
+
+function getStringWidth(str: string): number {
+  let width = 0
+  for (const char of str) {
+    width += isCJKorFullWidth(char) ? 2 : 1
+  }
+  return width
+}
+
+function isCJKorFullWidth(char: string): boolean {
+  const pattern = /[\u3000-\u9fff\uac00-\ud7af\uff01-\uff60]/
+  return pattern.test(char)
 }
 
 export function escapeCell(s: string) {

--- a/javascript/test/prettyTest.ts
+++ b/javascript/test/prettyTest.ts
@@ -116,6 +116,18 @@ Feature: hello
 `)
   })
 
+  it('renders tables with cjk characters', () => {
+    checkGherkinToAstToMarkdownToAstToGherkin(`Feature: hello
+
+  Scenario: one
+    Given a data table:
+      | 路     | numbers |
+      | 路     |       1 |
+      | 路步   |      10 |
+      | 路步路 |     100 |
+`)
+  })
+
   describe('DocString', () => {
     it('is rendered with type', () => {
       checkGherkinToAstToMarkdownToAstToGherkin(`Feature: hello


### PR DESCRIPTION
### 🤔 What's changed?

Count full-width characters as 2 spaces to determine table column width for formatting; with half-width characters counted as 1 space, as per existing implementation.

Implementation aligns with [vscode-markdown](https://github.com/yzhang-gh/vscode-markdown/blob/cfd568bf37223ac60d104f7dc6b2cd79ae130fda/src/tableFormatter.ts#L140) and [Cucumber Autocomplete extension](https://github.com/alexkrechik/VSCucumberAutoComplete/blob/ca571bc1ef434bbd7ba8c66ad76cd384947ba491/gserver/src/format.ts#L36).

### ⚡️ What's your motivation? 

Fixes cucumber/vscode#99.

Present formatted example:

```gherkin
Feature: Full width characters

  Scenario Outline: Format tables with full width characters
    Given a step table with full width characters
      | 路      | bar |
      | 路路路路路路 |  2步 |
      | 路路路    |  2步 |
```

Amended formatted example

> __Note:__ Appearance varies depending on font support with browsers or systems

```gherkin
Feature: Full width characters

  Scenario Outline: Format tables with full width characters
    Given a step table with full width characters
      | 路           | bar |
      | 路路路路路路 | 2步 |
      | 路路路       | 2步 |
```

#### Formatted example using a full-width character supported font

With the aforementioned 'amended formatted example' and the [Iosevka font](https://github.com/be5invis/Iosevka/releases/tag/v28.0.5), it appears as follows in the browser...

![Screenshot 2024-01-20 at 16 50 35](https://github.com/cucumber/gherkin-utils/assets/5904340/8739f204-5d5e-4149-ae3e-351d9d2f7a4d)

...and as follows in VSCode:

<img width="337" alt="Screenshot 2024-01-20 at 16 50 23" src="https://github.com/cucumber/gherkin-utils/assets/5904340/72b315f7-1456-420f-95f6-4f7a03d659c4">

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Whether should be classed as a 'bug' or an 'enhancement'.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.