### PR TITLE
Pretty comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.DS_Store
 /.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [JavaScript] Trim comment trailing whitespace and introduce space after comment hashtag ([#75](https://github.com/cucumber/gherkin-utils/pull/75))
 
 ## [9.0.0] - 2024-03-26
 ### Changed

--- a/javascript/src/pretty.ts
+++ b/javascript/src/pretty.ts
@@ -11,7 +11,7 @@ export default function pretty(
   let scenarioLevel = 1
   return walkGherkinDocument<string>(gherkinDocument, '', {
     comment(comment, content) {
-      return content.concat(comment.text).concat('\n')
+      return content.concat(prettyComment(comment.text)).concat('\n')
     },
     feature(feature, content) {
       return content
@@ -246,4 +246,9 @@ export function escapeCell(s: string) {
 
 function isNumeric(s: string) {
   return !isNaN(parseFloat(s))
+}
+
+export function prettyComment(comment: string): string {
+  // Ensure space after hashtag in a comment (`# `)
+  return comment.replace(/^(\s*#)(\S)/, '$1 $2').trimEnd()
 }

--- a/javascript/test/prettyTest.ts
+++ b/javascript/test/prettyTest.ts
@@ -5,7 +5,7 @@ import fg from 'fast-glob'
 import fs from 'fs'
 import path from 'path'
 
-import pretty, { escapeCell } from '../src/pretty'
+import pretty, { escapeCell, prettyComment } from '../src/pretty'
 import parse from './parse'
 
 const featuresPath = path.resolve(__dirname, '../node_modules/@cucumber/compatibility-kit/features')
@@ -286,6 +286,24 @@ Feature: hello
 
     it('escapes backslash', () => {
       assert.strictEqual(escapeCell('\\'), '\\\\')
+    })
+  })
+
+  describe('prettyComment', () => {
+    it('should add missing space after hashtag', () => {
+      assert.deepStrictEqual(prettyComment('#text'), '# text')
+    })
+    it('should retain leading whitespace', () => {
+      assert.deepStrictEqual(prettyComment('    # text'), '    # text')
+    })
+    it('should trim trailing whitespace', () => {
+      assert.deepStrictEqual(prettyComment('    # text    '), '    # text')
+    })
+    it('should retain spaces between hashtag and text', () => {
+      assert.deepStrictEqual(prettyComment('#    text'), '#    text')
+    })
+    it('inline hashtag should be ignored', () => {
+      assert.deepStrictEqual(prettyComment('number #1'), 'number #1')
     })
   })
 })

--- a/javascript/test/prettyTest.ts
+++ b/javascript/test/prettyTest.ts
@@ -302,7 +302,7 @@ Feature: hello
     it('should retain spaces between hashtag and text', () => {
       assert.deepStrictEqual(prettyComment('#    text'), '#    text')
     })
-    it('inline hashtag should be ignored', () => {
+    it('should not introduce space after inline hashtag', () => {
       assert.deepStrictEqual(prettyComment('number #1'), 'number #1')
     })
   })


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

- Trim trailing whitespace from comments
- Introduce a space between the hashtag of comments and text if one does not exist (`#content` -> `# content`)

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

- Consistent formatting
     - Removes redundant trailing whitespace, matching behaviour of all lines
     - Aligns with formatting of language key comment `#language: <key>` -> `# language: <key>`
     - Aligns with [formatting configuration of the VSCode extension for line comments](https://github.com/cucumber/vscode/blob/5a392aab9a3f1f424f80c5089e149caa51d0ce4f/language-configuration.json#L3) - which introduces a space after hashtags by default
     - Similar approach taken with code formatting tools such as [black](https://black.readthedocs.io/en/stable/)
     - Further decreases an element of misalignment across authored specifications i.e. comments will be visually more consistent

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

- How are comments handled in [gherkin markdown](https://github.com/cucumber/gherkin/blob/d95abc5acda98651535282438f73e1941d529449/MARKDOWN_WITH_GHERKIN.md)?
- Should be considered `Changed` in changelog?
- Comments are not currently indented in line with their scope. Would be great to resolve, though hard to discern whether there's a consistent indentation/formatting that can be applied e.g. if I comment out an entire scenario, how should its indentation be handled. Perhaps there are partial occurrences we can categorically format.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
