### PR TITLE
Generate OSGi infos in the manifest

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,6 +29,41 @@
     <tag>HEAD</tag>
   </scm>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>6.4.0</version>
+        <executions>
+          <execution>
+            <id>bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+            <configuration>
+            <bnd>
+            <![CDATA[ 
+            Export-Package: io.cucumber.gherkin.utils.*;-noimport:=true
+            Import-Package: *
+            ]]>
+            </bnd>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>io.cucumber</groupId>


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

This enables to embed OSGi metadata into the manifest of the produced jar file.

### ⚡️ What's your motivation? 

I use this in an [Eclipse plugin](https://github.com/cucumber/cucumber-eclipse/pull/553) and currently need to repack the original cucumber jars into an OSGi bundle, but adding the info at the source has much benefits:

1. Additional metadata in the manifest is ignored by other tools
2. At build time there is the most rich information about used packages and versions so better metadata can be generated
3. Using the original jar ensures it can later be identified as such e.g. with a security scanner
4. No risk that different people repack the same jar under the same name with different settings
5. only do the work once than on each build / consumer