### PR TITLE
Depend directly on gherking

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -43,15 +43,8 @@
     <dependencies>
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>messages</artifactId>
-            <version>[32.0.0,33.0.0)</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.cucumber</groupId>
             <artifactId>gherkin</artifactId>
             <version>39.0.0</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
@mpkorstanje I have some problems with maven complaining about dependency conflicts when using gherking-utils.

I found the setup here rather strange, because it uses cucumber-messages with an own version range and using gherking only as test dependency (what actually already depends on messages).

Also logically it seems better to just depend on gherking... and makes the pom simpler WDYT?