### PR TITLE
java: Exclude transitive messages from gherkin

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,6 +52,13 @@
             <artifactId>gherkin</artifactId>
             <version>39.0.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- Don't let Gherkin downgrade messages -->
+                    <groupId>io.cucumber</groupId>
+                    <artifactId>messages</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### 🤔 What's changed?

Because `gherkin-util` and `gherkin` both depend on `messages` and `gherkin` is a test scoped dependency, `gherkin` will downgrade the version range in messages. This is not ideal because it allows the range to be widened without testing.

Excluding `messages` from `gherkin` prevents this.


### ⚡️ What's your motivation? 

Fixes: https://github.com/cucumber/gherkin-utils/issues/172, https://github.com/cucumber/gherkin-utils/pull/171

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

@laeubi am I doing this correctly?

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)

