### PR TITLE
fix(formatting): left-align non-number columns starting with number

### DIFF
--- a/javascript/src/pretty.ts
+++ b/javascript/src/pretty.ts
@@ -245,5 +245,5 @@ export function escapeCell(s: string) {
 }
 
 function isNumeric(s: string) {
-  return !Number.isNaN(parseFloat(s))
+  return !Number.isNaN(Number(s))
 }

--- a/javascript/test/prettyTest.ts
+++ b/javascript/test/prettyTest.ts
@@ -100,10 +100,12 @@ Feature: hello
     Given a a <text> and a <number>
 
     Examples: some data
-      | text | number |
-      | a    |      1 |
-      | ab   |     10 |
-      | abc  |    100 |
+      | text | number | hybrid |
+      |      |        |        |
+      | a    |      1 | 2abc   |
+      | ab   |     10 | 20bc   |
+      | abc  |    100 | 200c   |
+      | abcd |  100.1 | 200c   |
 `)
   })
 
@@ -112,10 +114,12 @@ Feature: hello
 
   Scenario: one
     Given a data table:
-      | text | numbers |
-      | a    |       1 |
-      | ab   |      10 |
-      | abc  |     100 |
+      | text | numbers | hybrid |
+      |      |         |        |
+      | a    |       1 | 2abc   |
+      | ab   |      10 | 20bc   |
+      | abc  |     100 | 200c   |
+      | abcd |   100.1 | 200c   |
 `)
   })
 
@@ -124,10 +128,12 @@ Feature: hello
 
   Scenario: one
     Given a data table:
-      | 路     | numbers |
-      | 路     |       1 |
-      | 路步   |      10 |
-      | 路步路 |     100 |
+      | 路     | numbers | hybrid |
+      |        |         |        |
+      | 路     |       1 | 2abc   |
+      | 路步   |      10 | 20bc   |
+      | 路步路 |     100 | 200c   |
+      | 路步路 |   100.1 | 200c   |
 `)
   })
 


### PR DESCRIPTION
### 🤔 What's changed?

Ref #174 

`parseFloat` parses a float out of a string until it cannot, making the `!Number.isNaN` pass if the provided string starts with a number.

### ⚡️ What's your motivation? 

For alignment to be a bit more consistent.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

nope

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
